### PR TITLE
fix: prevent text wrapping in pillar summary table headers

### DIFF
--- a/src/app/features/assessment/overall-progress-summary.component.scss
+++ b/src/app/features/assessment/overall-progress-summary.component.scss
@@ -34,6 +34,13 @@
       text-transform: uppercase;
       letter-spacing: 0.5px;
       margin-top: 0.25rem;
+      white-space: nowrap; // Prevent text wrapping for stat labels
+    }
+
+    // Ensure stat columns have adequate space
+    .row .col-4 {
+      min-width: 80px;
+      padding: 0 0.25rem;
     }
   }
 

--- a/src/app/features/assessment/pillar-summary.component.scss
+++ b/src/app/features/assessment/pillar-summary.component.scss
@@ -18,6 +18,36 @@
   background-color: rgba(0, 0, 0, 0.03);
 }
 
+// Prevent table headers from wrapping
+.table {
+  th {
+    white-space: nowrap;
+    vertical-align: middle;
+  }
+
+  td {
+    vertical-align: middle;
+  }
+
+  // Ensure specific columns have appropriate min-width
+  th:nth-child(4), // "Completed" column
+  td:nth-child(4) {
+    min-width: 90px;
+    white-space: nowrap;
+  }
+
+  th:nth-child(3), // "Items" column
+  td:nth-child(3) {
+    min-width: 70px;
+    white-space: nowrap;
+  }
+
+  th:nth-child(6), // "Action" column
+  td:nth-child(6) {
+    min-width: 100px;
+  }
+}
+
 .progress {
   border-radius: 12px;
   overflow: hidden;
@@ -60,5 +90,32 @@
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+// Responsive styles for mobile devices
+@media (max-width: 768px) {
+  .table {
+    font-size: 0.875rem;
+
+    th, td {
+      padding: 0.5rem 0.25rem;
+    }
+
+    // On mobile, ensure minimum column widths are respected
+    th:nth-child(4),
+    td:nth-child(4) {
+      min-width: 80px;
+    }
+
+    th:nth-child(3),
+    td:nth-child(3) {
+      min-width: 60px;
+    }
+  }
+
+  .btn {
+    font-size: 0.75rem;
+    padding: 0.25rem 0.5rem;
   }
 }

--- a/src/app/features/assessment/pillar-summary.component.scss
+++ b/src/app/features/assessment/pillar-summary.component.scss
@@ -45,6 +45,7 @@
   th:nth-child(6), // "Action" column
   td:nth-child(6) {
     min-width: 100px;
+    white-space: nowrap;
   }
 }
 


### PR DESCRIPTION
- Add white-space: nowrap to table headers to prevent 'Completed' from wrapping
- Set minimum widths for Items and Completed columns (70px and 90px respectively)
- Add responsive styles for mobile devices with smaller minimum widths
- Fix text wrapping in overall progress summary stat labels
- Ensure proper column spacing with min-width constraints

Fixes issue where 'Completed' word was wrapping to second line in assessment cards